### PR TITLE
Fix encoding comments in application.properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,7 @@ spring.datasource.username=admin
 spring.datasource.password=admin11!!
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 
-# ???
+# UTF-8 encoding settings
 spring.http.encoding.charset=UTF-8
 spring.http.encoding.enabled=true
 spring.http.encoding.force=true
@@ -18,10 +18,10 @@ spring.thymeleaf.cache=false
 mybatis.mapper-locations=classpath:mapper/*.xml
 mybatis.type-aliases-package=com.example.demo.model
 
-# ?? ?? ?? ??
+# File upload directory
 file.upload-dir=D:/uploads
 
-# ?? ??? ??
+# Static resource locations
 spring.web.resources.static-locations=classpath:/static/,file:///D:/uploads/
 
 spring.servlet.multipart.max-file-size=20MB


### PR DESCRIPTION
## Summary
- replace garbled comment lines in `application.properties` with UTF‑8 descriptions

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e953b80883209650c2af780afb1b